### PR TITLE
Fix eh specifiers

### DIFF
--- a/keycard_go/impl.nim
+++ b/keycard_go/impl.nim
@@ -1,4 +1,7 @@
-type KeycardSignalCallback* = proc(signal: cstring): void {.cdecl.}
+# go functions do not raise nim exceptions and do not interact with the Nim gc
+{.push raises: [], gcsafe.}
+
+type KeycardSignalCallback* = proc(signal: cstring): void {.cdecl, gcsafe, raises: [].}
 
 proc free*(param: pointer) {.importc: "Free".}
 proc setSignalEventCallback*(callback: KeycardSignalCallback) {.importc: "KeycardSetSignalEventCallback".}


### PR DESCRIPTION
Per
https://status-im.github.io/nim-style-guide/interop.c.html#functions-and-types, imported functions must be annotated with exception information.

If this is not done, Nim assumes the worst case that the function potentially could raise an exception which breaks compile-time exception safety analysis.