### PR TITLE
feat: add api v2 methods

### DIFF
--- a/keycard_go.nim
+++ b/keycard_go.nim
@@ -22,6 +22,16 @@ proc keycardCancelFlow*(): string =
   defer: go_shim.free(funcOut)
   return $funcOut
 
+proc keycardInitializeRPC*(): string =
+  var funcOut = go_shim.keycardInitializeRPC()
+  defer: go_shim.free(funcOut)
+  return $funcOut
+
+proc keycardCallRPC*(params: string): string =
+  var funcOut = go_shim.keycardCallRPC(params.cstring)
+  defer: go_shim.free(funcOut)
+  return $funcOut
+
 proc setSignalEventCallback*(callback: KeycardSignalCallback) =
   go_shim.setSignalEventCallback(callback)
 

--- a/keycard_go/impl.nim
+++ b/keycard_go/impl.nim
@@ -1,6 +1,8 @@
 # go functions do not raise nim exceptions and do not interact with the Nim gc
 {.push raises: [], gcsafe.}
 
+# NOTE: Methods here begin with "Keycard" to avoid name conflicts with status-go
+
 type KeycardSignalCallback* = proc(signal: cstring): void {.cdecl, gcsafe, raises: [].}
 
 proc free*(param: pointer) {.importc: "Free".}
@@ -10,6 +12,8 @@ proc keycardInitFlow*(storageDir: cstring): cstring {.importc: "KeycardInitFlow"
 proc keycardStartFlow*(flowType: cint, jsonParams: cstring): cstring {.importc: "KeycardStartFlow".}
 proc keycardResumeFlow*(jsonParams: cstring): cstring {.importc: "KeycardResumeFlow".}
 proc keycardCancelFlow*(): cstring {.importc: "KeycardCancelFlow".}
+proc keycardInitializeRPC*(): cstring {.importc: "KeycardInitializeRPC".}
+proc keycardCallRPC*(params: cstring): cstring {.importc: "KeycardCallRPC".}
 
 # availale in test mode only
 proc mockedLibRegisterKeycard*(cardIndex: cint, readerState: cint, keycardState: cint, mockedKeycard: cstring, mockedKeycardHelper: cstring): cstring {.importc: "MockedLibRegisterKeycard".}


### PR DESCRIPTION
Requires https://github.com/keycard-tech/status-keycard-go/pull/13.

Added `keycardInitializeRPC` and `keycardCallRPC`, as implemented in https://github.com/keycard-tech/status-keycard-go/pull/13.

