### PR TITLE
chore: endpoints for managing/simulating keycard

### DIFF
--- a/keycard_go.nim
+++ b/keycard_go.nim
@@ -10,29 +10,29 @@ proc keycardCallRPC*(params: string): string =
 proc setSignalEventCallback*(callback: KeycardSignalCallback) =
   go_shim.setSignalEventCallback(callback)
 
-# availale in test mode only
-proc mockedLibRegisterKeycard*(cardIndex: int, readerState: int, keycardState: int, mockedKeycard: string, mockedKeycardHelper: string): string =
-  var funcOut = go_shim.mockedLibRegisterKeycard(cardIndex.cint, readerState.cint, keycardState.cint, mockedKeycard.cstring, mockedKeycardHelper.cstring)
-  defer: go_shim.free(funcOut)
-  return $funcOut
+# Available only when status-keycard-qt is built with USE_SIMULATED_KEYCARD (app built with -d:useSimulatedKeycard)
+when defined(useSimulatedKeycard):
+  proc keycardTestCreateCard*(cardId: string): string =
+    var funcOut = go_shim.keycardTestCreateCard(cardId.cstring)
+    defer: go_shim.free(funcOut)
+    return $funcOut
 
-proc mockedLibReaderPluggedIn*(): string =
-  var funcOut = go_shim.mockedLibReaderPluggedIn()
-  defer: go_shim.free(funcOut)
-  return $funcOut
+  proc keycardTestInsertCard*(cardId: string): string =
+    var funcOut = go_shim.keycardTestInsertCard(cardId.cstring)
+    defer: go_shim.free(funcOut)
+    return $funcOut
 
-proc mockedLibReaderUnplugged*(): string =
-  var funcOut = go_shim.mockedLibReaderUnplugged()
-  defer: go_shim.free(funcOut)
-  return $funcOut
+  proc keycardTestRemoveCard*(): string =
+    var funcOut = go_shim.keycardTestRemoveCard()
+    defer: go_shim.free(funcOut)
+    return $funcOut
 
-proc mockedLibKeycardInserted*(cardIndex: int): string =
-  var funcOut = go_shim.mockedLibKeycardInserted(cardIndex.cint)
-  defer: go_shim.free(funcOut)
-  return $funcOut
+  proc keycardTestPlugReader*(): string =
+    var funcOut = go_shim.keycardTestPlugReader()
+    defer: go_shim.free(funcOut)
+    return $funcOut
 
-proc mockedLibKeycardRemoved*(): string =
-  var funcOut = go_shim.mockedLibKeycardRemoved()
-  defer: go_shim.free(funcOut)
-  return $funcOut
-
+  proc keycardTestUnplugReader*(): string =
+    var funcOut = go_shim.keycardTestUnplugReader()
+    defer: go_shim.free(funcOut)
+    return $funcOut

--- a/keycard_go.nim
+++ b/keycard_go.nim
@@ -2,31 +2,6 @@ import ./keycard_go/impl as go_shim
 
 export KeycardSignalCallback
 
-proc keycardInitFlow*(storageDir: string): string =
-  var funcOut = go_shim.keycardInitFlow(storageDir.cstring)
-  defer: go_shim.free(funcOut)
-  return $funcOut
-
-proc keycardStartFlow*(flowType: int, jsonParams: string): string =
-  var funcOut = go_shim.keycardStartFlow(flowType.cint, jsonParams.cstring)
-  defer: go_shim.free(funcOut)
-  return $funcOut
-
-proc keycardResumeFlow*(jsonParams: string): string =
-  var funcOut = go_shim.keycardResumeFlow(jsonParams.cstring)
-  defer: go_shim.free(funcOut)
-  return $funcOut
-
-proc keycardCancelFlow*(): string =
-  var funcOut = go_shim.keycardCancelFlow()
-  defer: go_shim.free(funcOut)
-  return $funcOut
-
-proc keycardInitializeRPC*(): string =
-  var funcOut = go_shim.keycardInitializeRPC()
-  defer: go_shim.free(funcOut)
-  return $funcOut
-
 proc keycardCallRPC*(params: string): string =
   var funcOut = go_shim.keycardCallRPC(params.cstring)
   defer: go_shim.free(funcOut)
@@ -61,5 +36,3 @@ proc mockedLibKeycardRemoved*(): string =
   defer: go_shim.free(funcOut)
   return $funcOut
 
-proc ResetAPI*() =
-  go_shim.resetAPI()

--- a/keycard_go/impl.nim
+++ b/keycard_go/impl.nim
@@ -10,9 +10,10 @@ proc setSignalEventCallback*(callback: KeycardSignalCallback) {.importc: "Keycar
 
 proc keycardCallRPC*(params: cstring): cstring {.importc: "KeycardCallRPC".}
 
-# availale in test mode only
-proc mockedLibRegisterKeycard*(cardIndex: cint, readerState: cint, keycardState: cint, mockedKeycard: cstring, mockedKeycardHelper: cstring): cstring {.importc: "MockedLibRegisterKeycard".}
-proc mockedLibReaderPluggedIn*(): cstring {.importc: "MockedLibReaderPluggedIn".}
-proc mockedLibReaderUnplugged*(): cstring {.importc: "MockedLibReaderUnplugged".}
-proc mockedLibKeycardInserted*(cardIndex: cint): cstring {.importc: "MockedLibKeycardInserted".}
-proc mockedLibKeycardRemoved*(): cstring {.importc: "MockedLibKeycardRemoved".}
+# Available only when status-keycard-qt is built with USE_SIMULATED_KEYCARD (app built with -d:useSimulatedKeycard)
+when defined(useSimulatedKeycard):
+  proc keycardTestCreateCard*(cardId: cstring): cstring {.importc: "KeycardTestCreateCard".}
+  proc keycardTestInsertCard*(cardId: cstring): cstring {.importc: "KeycardTestInsertCard".}
+  proc keycardTestRemoveCard*(): cstring {.importc: "KeycardTestRemoveCard".}
+  proc keycardTestPlugReader*(): cstring {.importc: "KeycardTestPlugReader".}
+  proc keycardTestUnplugReader*(): cstring {.importc: "KeycardTestUnplugReader".}

--- a/keycard_go/impl.nim
+++ b/keycard_go/impl.nim
@@ -7,13 +7,7 @@ type KeycardSignalCallback* = proc(signal: cstring): void {.cdecl, gcsafe, raise
 
 proc free*(param: pointer) {.importc: "Free".}
 proc setSignalEventCallback*(callback: KeycardSignalCallback) {.importc: "KeycardSetSignalEventCallback".}
-proc resetAPI*() {.importc: "ResetAPI".}
 
-proc keycardInitFlow*(storageDir: cstring): cstring {.importc: "KeycardInitFlow".}
-proc keycardStartFlow*(flowType: cint, jsonParams: cstring): cstring {.importc: "KeycardStartFlow".}
-proc keycardResumeFlow*(jsonParams: cstring): cstring {.importc: "KeycardResumeFlow".}
-proc keycardCancelFlow*(): cstring {.importc: "KeycardCancelFlow".}
-proc keycardInitializeRPC*(): cstring {.importc: "KeycardInitializeRPC".}
 proc keycardCallRPC*(params: cstring): cstring {.importc: "KeycardCallRPC".}
 
 # availale in test mode only


### PR DESCRIPTION
Added endpoints from https://github.com/status-im/status-keycard-qt/pull/30